### PR TITLE
rtps/rtpsimpl: affordance to configure underlying rtps implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ set(COMMKIT_SRCS
     src/nodeimpl.cpp
     src/publisher.cpp
     src/publisherimpl.cpp
+    src/rtpsimpl.cpp
     src/subscriber.cpp
     src/subscriberimpl.cpp
     src/topic.cpp

--- a/include/commkit/commkit.h
+++ b/include/commkit/commkit.h
@@ -12,3 +12,4 @@
 #include <commkit/node.h>
 #include <commkit/publisher.h>
 #include <commkit/subscriber.h>
+#include <commkit/rtps.h>

--- a/include/commkit/rtps.h
+++ b/include/commkit/rtps.h
@@ -1,0 +1,24 @@
+#pragma once
+
+/*
+ * Utilities (hopefully very few) to configure/manipulate
+ * the underlying RTPS implementation.
+ */
+
+namespace commkit
+{
+
+/*
+ * Currently these map directly to Fast-RTPS log levels,
+ * consider reorg'ing if necessary in the future.
+ */
+enum RtpsLogVerbosity {
+    RTPS_VERBOSITY_QUIET,
+    RTPS_VERBOSITY_ERROR,
+    RTPS_VERBOSITY_WARNING,
+    RTPS_VERBOSITY_INFO
+};
+
+void setRtpsLogVerbosity(RtpsLogVerbosity level);
+
+} // namespace commkit

--- a/src/rtpsimpl.cpp
+++ b/src/rtpsimpl.cpp
@@ -1,0 +1,13 @@
+#include <commkit/rtps.h>
+
+#include <fastrtps/log/Log.h>
+
+namespace commkit
+{
+
+void setRtpsLogVerbosity(RtpsLogVerbosity level)
+{
+    eprosima::Log::setVerbosity(static_cast<eprosima::LOG_VERBOSITY_LVL>(level));
+}
+
+} // namespace commkit


### PR DESCRIPTION
currently just used to specify fast-rtps log level
