### PR TITLE
Change Payload::toReader API to avoid dangling pointer. 

### DIFF
--- a/include/commkit/subscriber.h
+++ b/include/commkit/subscriber.h
@@ -56,29 +56,7 @@ struct COMMKIT_API Payload {
     }
 
 #ifndef COMMKIT_NO_CAPNP
-    capnp::FlatArrayMessageReader toReader(bool *ok = nullptr)
-    {
-        /*
-         * Use FlatArrayMessageReader since that's what Publisher uses for now.
-         * Ultimately want a strategy that involves less copying.
-         */
-
-        using capnp::word;
-
-        if (len % sizeof(word) == 0) {
-            if (ok) {
-                *ok = true;
-            }
-            auto wb =
-                kj::ArrayPtr<const word>(reinterpret_cast<const word *>(bytes), len / sizeof(word));
-            return capnp::FlatArrayMessageReader(wb);
-        }
-
-        if (ok) {
-            *ok = false;
-        }
-        return capnp::FlatArrayMessageReader(kj::ArrayPtr<const word>(nullptr, (size_t)0));
-    }
+    capnp::FlatArrayMessageReader toReader(bool *ok = nullptr);
 #endif // COMMKIT_NO_CAPNP
 };
 

--- a/include/commkit/subscriber.h
+++ b/include/commkit/subscriber.h
@@ -56,8 +56,7 @@ struct COMMKIT_API Payload {
     }
 
 #ifndef COMMKIT_NO_CAPNP
-    template <typename T>
-    typename T::Reader toReader(bool *ok = nullptr)
+    capnp::FlatArrayMessageReader toReader(bool *ok = nullptr)
     {
         /*
          * Use FlatArrayMessageReader since that's what Publisher uses for now.
@@ -72,13 +71,13 @@ struct COMMKIT_API Payload {
             }
             auto wb =
                 kj::ArrayPtr<const word>(reinterpret_cast<const word *>(bytes), len / sizeof(word));
-            return capnp::FlatArrayMessageReader(wb).getRoot<T>();
+            return capnp::FlatArrayMessageReader(wb);
         }
 
         if (ok) {
             *ok = false;
         }
-        return typename T::Reader();
+        return capnp::FlatArrayMessageReader(kj::ArrayPtr<const word>(nullptr, (size_t)0));
     }
 #endif // COMMKIT_NO_CAPNP
 };

--- a/src/subscriber.cpp
+++ b/src/subscriber.cpp
@@ -48,4 +48,30 @@ std::string Subscriber::name() const
     return impl->name();
 }
 
+#ifndef COMMKIT_NO_CAPNP
+capnp::FlatArrayMessageReader Payload::toReader(bool *ok)
+{
+    /*
+     * Use FlatArrayMessageReader since that's what Publisher uses for now.
+     * Ultimately want a strategy that involves less copying.
+     */
+
+    using capnp::word;
+
+    if (len % sizeof(word) == 0) {
+        if (ok) {
+            *ok = true;
+        }
+        auto wb =
+            kj::ArrayPtr<const word>(reinterpret_cast<const word *>(bytes), len / sizeof(word));
+        return capnp::FlatArrayMessageReader(wb);
+    }
+
+    if (ok) {
+        *ok = false;
+    }
+    return capnp::FlatArrayMessageReader(kj::ArrayPtr<const word>(nullptr, (size_t)0));
+}
+#endif
+
 } // namespace commkit


### PR DESCRIPTION
The Reader returned by getRoot contains pointers into the temporary
FlatMessageArrayReader, which are invalidated when the function returns.

Unfortunately, this results in an API change, so that the caller can own
the FlatMessageArrayReader. To update your code, replace

    auto msg = p.toReader<redrider::Foo>();

with

```
auto reader = p.toReader();
auto msg = reader.getRoot<redrider::Foo>();
````